### PR TITLE
Added dependencies for Manga.WebApi.Tests to pass

### DIFF
--- a/manga/test/Manga.WebApi.Tests/Manga.WebApi.Tests.csproj
+++ b/manga/test/Manga.WebApi.Tests/Manga.WebApi.Tests.csproj
@@ -24,6 +24,8 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />


### PR DESCRIPTION
This resolves issue #22 . Added Microsoft.AspNetCore.Mvc and Microsoft.AspNetCore.Diagnostics packages the Manga.WebApi.Tests.