### PR TITLE
Refactor type checking for Exception filter

### DIFF
--- a/source/Manga.WebApi/Filters/BusinessExceptionFilter.cs
+++ b/source/Manga.WebApi/Filters/BusinessExceptionFilter.cs
@@ -1,4 +1,4 @@
-﻿namespace Manga.WebApi.Filters
+namespace Manga.WebApi.Filters
 {
     using Manga.Domain;
     using Microsoft.AspNetCore.Mvc;
@@ -8,14 +8,13 @@
     {
         public void OnException(ExceptionContext context)
         {
-            DomainException domainException = context.Exception as DomainException;
-            if (domainException != null)
+            if (context.Exception is DomainException)
             {
                 var problemDetails = new ProblemDetails
                 {
                     Status = 400,
                     Title = "Bad Request",
-                    Detail = domainException.Message
+                    Detail = context.Exception.Message
                 };
 
                 context.Result = new BadRequestObjectResult(problemDetails);


### PR DESCRIPTION
I believe this code
```cs
var domainException = context.Exception as DomainException;
if(domainException != null)
{
    // ...
}
```
Is equivalent to:
```cs
if(context.Exception is DomainException)
{
    // ...
}
```

## Why should we switch?
- _(subjective)_ it looks a bit nicer.
- We are more clearly expressing what we're trying to do here.
- With C# 8's nullable references enabled, the old way would generate a warning for the cast.