### PR TITLE
Adds semantic to boundaries

### DIFF
--- a/src/Application/Boundaries/CloseAccount/CloseAccountInput.cs
+++ b/src/Application/Boundaries/CloseAccount/CloseAccountInput.cs
@@ -3,7 +3,7 @@ namespace Application.Boundaries.CloseAccount
     using System;
     using Exceptions;
 
-    public sealed class CloseAccountInput
+    public sealed class CloseAccountInput : IUseCaseInput
     {
         public Guid AccountId { get; }
 

--- a/src/Application/Boundaries/CloseAccount/CloseAccountOutput.cs
+++ b/src/Application/Boundaries/CloseAccount/CloseAccountOutput.cs
@@ -3,7 +3,7 @@ namespace Application.Boundaries.CloseAccount
     using System;
     using Domain.Accounts;
 
-    public sealed class CloseAccountOutput
+    public sealed class CloseAccountOutput : IUseCaseOutput
     {
         public Guid AccountId { get; }
 

--- a/src/Application/Boundaries/CloseAccount/IOutputPort.cs
+++ b/src/Application/Boundaries/CloseAccount/IOutputPort.cs
@@ -1,8 +1,5 @@
 namespace Application.Boundaries.CloseAccount
 {
     public interface IOutputPort
-    {
-        void Standard(CloseAccountOutput closeAccountOutput);
-        void NotFound(string message);
-    }
+        : IOutputPortStandard<CloseAccountOutput>, IOutputPortNotFound { }
 }

--- a/src/Application/Boundaries/CloseAccount/IUseCase.cs
+++ b/src/Application/Boundaries/CloseAccount/IUseCase.cs
@@ -1,9 +1,4 @@
 namespace Application.Boundaries.CloseAccount
 {
-    using System.Threading.Tasks;
-
-    public interface IUseCase
-    {
-        Task Execute(CloseAccountInput closeAccountInput);
-    }
+    public interface IUseCase : IUseCase<CloseAccountInput> { }
 }

--- a/src/Application/Boundaries/Deposit/DepositInput.cs
+++ b/src/Application/Boundaries/Deposit/DepositInput.cs
@@ -4,7 +4,7 @@ namespace Application.Boundaries.Deposit
     using Exceptions;
     using Domain.ValueObjects;
 
-    public sealed class DepositInput
+    public sealed class DepositInput : IUseCaseInput
     {
         public Guid AccountId { get; }
         public PositiveMoney Amount { get; }

--- a/src/Application/Boundaries/Deposit/DepositOutput.cs
+++ b/src/Application/Boundaries/Deposit/DepositOutput.cs
@@ -3,7 +3,7 @@ namespace Application.Boundaries.Deposit
     using Domain.Accounts;
     using Domain.ValueObjects;
 
-    public sealed class DepositOutput
+    public sealed class DepositOutput : IUseCaseOutput
     {
         public Transaction Transaction { get; }
         public Money UpdatedBalance { get; }

--- a/src/Application/Boundaries/Deposit/IOutputPort.cs
+++ b/src/Application/Boundaries/Deposit/IOutputPort.cs
@@ -1,8 +1,5 @@
 namespace Application.Boundaries.Deposit
 {
     public interface IOutputPort
-    {
-        void Standard(DepositOutput depositOutput);
-        void NotFound(string message);
-    }
+        : IOutputPortStandard<DepositOutput>, IOutputPortNotFound { }
 }

--- a/src/Application/Boundaries/Deposit/IUseCase.cs
+++ b/src/Application/Boundaries/Deposit/IUseCase.cs
@@ -1,9 +1,4 @@
 namespace Application.Boundaries.Deposit
 {
-    using System.Threading.Tasks;
-
-    public interface IUseCase
-    {
-        Task Execute(DepositInput depositInput);
-    }
+    public interface IUseCase : IUseCase<DepositInput> { }
 }

--- a/src/Application/Boundaries/GetAccountDetails/GetAccountDetailsInput.cs
+++ b/src/Application/Boundaries/GetAccountDetails/GetAccountDetailsInput.cs
@@ -3,7 +3,7 @@ namespace Application.Boundaries.GetAccountDetails
     using System;
     using Exceptions;
 
-    public sealed class GetAccountDetailsInput
+    public sealed class GetAccountDetailsInput : IUseCaseInput
     {
         public Guid AccountId { get; }
 

--- a/src/Application/Boundaries/GetAccountDetails/GetAccountDetailsOutput.cs
+++ b/src/Application/Boundaries/GetAccountDetails/GetAccountDetailsOutput.cs
@@ -5,7 +5,7 @@ namespace Application.Boundaries.GetAccountDetails
     using Domain.Accounts;
     using Domain.ValueObjects;
 
-    public sealed class GetAccountDetailsOutput
+    public sealed class GetAccountDetailsOutput : IUseCaseOutput
     {
         public Guid AccountId { get; }
         public Money CurrentBalance { get; }

--- a/src/Application/Boundaries/GetAccountDetails/IOutputPort.cs
+++ b/src/Application/Boundaries/GetAccountDetails/IOutputPort.cs
@@ -1,8 +1,5 @@
 namespace Application.Boundaries.GetAccountDetails
 {
     public interface IOutputPort
-    {
-        void Standard(GetAccountDetailsOutput getAccountDetailsOutput);
-        void NotFound(string message);
-    }
+        : IOutputPortStandard<GetAccountDetailsOutput>, IOutputPortNotFound { }
 }

--- a/src/Application/Boundaries/GetAccountDetails/IUseCase.cs
+++ b/src/Application/Boundaries/GetAccountDetails/IUseCase.cs
@@ -1,9 +1,4 @@
 namespace Application.Boundaries.GetAccountDetails
 {
-    using System.Threading.Tasks;
-
-    public interface IUseCase
-    {
-        Task Execute(GetAccountDetailsInput getAccountDetailsInput);
-    }
+    public interface IUseCase : IUseCase<GetAccountDetailsInput> { }
 }

--- a/src/Application/Boundaries/GetCustomerDetails/GetCustomerDetailsInput.cs
+++ b/src/Application/Boundaries/GetCustomerDetails/GetCustomerDetailsInput.cs
@@ -3,7 +3,7 @@ namespace Application.Boundaries.GetCustomerDetails
     using System;
     using Exceptions;
 
-    public sealed class GetCustomerDetailsInput
+    public sealed class GetCustomerDetailsInput : IUseCaseInput
     {
         public Guid CustomerId { get; }
 

--- a/src/Application/Boundaries/GetCustomerDetails/GetCustomerDetailsOutput.cs
+++ b/src/Application/Boundaries/GetCustomerDetails/GetCustomerDetailsOutput.cs
@@ -5,7 +5,7 @@ namespace Application.Boundaries.GetCustomerDetails
     using Domain.Customers;
     using Domain.ValueObjects;
 
-    public sealed class GetCustomerDetailsOutput
+    public sealed class GetCustomerDetailsOutput : IUseCaseOutput
     {
         public Guid CustomerId { get; }
         public SSN SSN { get; }

--- a/src/Application/Boundaries/GetCustomerDetails/IOutputPort.cs
+++ b/src/Application/Boundaries/GetCustomerDetails/IOutputPort.cs
@@ -1,8 +1,5 @@
 namespace Application.Boundaries.GetCustomerDetails
 {
     public interface IOutputPort
-    {
-        void Standard(GetCustomerDetailsOutput getCustomerDetailsOutput);
-        void NotFound(string message);
-    }
+        : IOutputPortStandard<GetCustomerDetailsOutput>, IOutputPortNotFound { }
 }

--- a/src/Application/Boundaries/GetCustomerDetails/IUseCase.cs
+++ b/src/Application/Boundaries/GetCustomerDetails/IUseCase.cs
@@ -1,9 +1,4 @@
 namespace Application.Boundaries.GetCustomerDetails
 {
-    using System.Threading.Tasks;
-
-    public interface IUseCase
-    {
-        Task Execute(GetCustomerDetailsInput getCustomerDetailsInput);
-    }
+    public interface IUseCase : IUseCase<GetCustomerDetailsInput> { }
 }

--- a/src/Application/Boundaries/IOutputPortNotFound.cs
+++ b/src/Application/Boundaries/IOutputPortNotFound.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Boundaries
+{
+    public interface IOutputPortNotFound
+    {
+        void NotFound(string message);
+    }
+}

--- a/src/Application/Boundaries/IOutputPortStandard.cs
+++ b/src/Application/Boundaries/IOutputPortStandard.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Boundaries
+{
+    public interface IOutputPortStandard<in TUseCaseOutput> where TUseCaseOutput : IUseCaseOutput
+    {
+        void Standard(TUseCaseOutput output);
+    }
+}

--- a/src/Application/Boundaries/IUseCase.cs
+++ b/src/Application/Boundaries/IUseCase.cs
@@ -1,0 +1,9 @@
+﻿namespace Application.Boundaries
+{
+    using System.Threading.Tasks;
+
+    public interface IUseCase<in TUseCaseInput> where TUseCaseInput : IUseCaseInput
+    {
+        Task Execute(TUseCaseInput input);
+    }
+}

--- a/src/Application/Boundaries/IUseCaseInput.cs
+++ b/src/Application/Boundaries/IUseCaseInput.cs
@@ -1,0 +1,4 @@
+﻿namespace Application.Boundaries
+{
+    public interface IUseCaseInput { }
+}

--- a/src/Application/Boundaries/IUseCaseOutput.cs
+++ b/src/Application/Boundaries/IUseCaseOutput.cs
@@ -1,0 +1,4 @@
+﻿namespace Application.Boundaries
+{
+    public interface IUseCaseOutput { }
+}

--- a/src/Application/Boundaries/Register/IOutputPort.cs
+++ b/src/Application/Boundaries/Register/IOutputPort.cs
@@ -1,7 +1,5 @@
 namespace Application.Boundaries.Register
 {
     public interface IOutputPort
-    {
-        void Standard(RegisterOutput registerOutput);
-    }
+        : IOutputPortStandard<RegisterOutput> { }
 }

--- a/src/Application/Boundaries/Register/IUseCase.cs
+++ b/src/Application/Boundaries/Register/IUseCase.cs
@@ -1,9 +1,4 @@
 namespace Application.Boundaries.Register
 {
-    using System.Threading.Tasks;
-
-    public interface IUseCase
-    {
-        Task Execute(RegisterInput registerInput);
-    }
+    public interface IUseCase : IUseCase<RegisterInput> { }
 }

--- a/src/Application/Boundaries/Register/RegisterInput.cs
+++ b/src/Application/Boundaries/Register/RegisterInput.cs
@@ -2,7 +2,7 @@ namespace Application.Boundaries.Register
 {
     using Domain.ValueObjects;
 
-    public sealed class RegisterInput
+    public sealed class RegisterInput : IUseCaseInput
     {
         public SSN SSN { get; }
         public Name Name { get; }

--- a/src/Application/Boundaries/Register/RegisterOutput.cs
+++ b/src/Application/Boundaries/Register/RegisterOutput.cs
@@ -4,7 +4,7 @@ namespace Application.Boundaries.Register
     using Domain.Accounts;
     using Domain.Customers;
 
-    public sealed class RegisterOutput
+    public sealed class RegisterOutput : IUseCaseOutput
     {
         public Customer Customer { get; }
         public Account Account { get; }

--- a/src/Application/Boundaries/Transfer/IOutputPort.cs
+++ b/src/Application/Boundaries/Transfer/IOutputPort.cs
@@ -1,8 +1,5 @@
 namespace Application.Boundaries.Transfer
 {
     public interface IOutputPort
-    {
-        void Standard(TransferOutput transferOutput);
-        void NotFound(string message);
-    }
+        : IOutputPortStandard<TransferOutput>, IOutputPortNotFound { }
 }

--- a/src/Application/Boundaries/Transfer/IUseCase.cs
+++ b/src/Application/Boundaries/Transfer/IUseCase.cs
@@ -1,9 +1,4 @@
 namespace Application.Boundaries.Transfer
 {
-    using System.Threading.Tasks;
-
-    public interface IUseCase
-    {
-        Task Execute(TransferInput transferInput);
-    }
+    public interface IUseCase : IUseCase<TransferInput> { }
 }

--- a/src/Application/Boundaries/Transfer/TransferInput.cs
+++ b/src/Application/Boundaries/Transfer/TransferInput.cs
@@ -4,7 +4,7 @@ namespace Application.Boundaries.Transfer
     using Exceptions;
     using Domain.ValueObjects;
 
-    public sealed class TransferInput
+    public sealed class TransferInput : IUseCaseInput
     {
         public Guid OriginAccountId { get; }
         public Guid DestinationAccountId { get; }

--- a/src/Application/Boundaries/Transfer/TransferOutput.cs
+++ b/src/Application/Boundaries/Transfer/TransferOutput.cs
@@ -4,7 +4,7 @@ namespace Application.Boundaries.Transfer
     using Domain.Accounts;
     using Domain.ValueObjects;
 
-    public sealed class TransferOutput
+    public sealed class TransferOutput : IUseCaseOutput
     {
         public Transaction Transaction { get; }
         public Money UpdatedBalance { get; }

--- a/src/Application/Boundaries/Withdraw/IOutputPort.cs
+++ b/src/Application/Boundaries/Withdraw/IOutputPort.cs
@@ -1,9 +1,8 @@
 namespace Application.Boundaries.Withdraw
 {
     public interface IOutputPort
+        : IOutputPortStandard<WithdrawOutput>, IOutputPortNotFound
     {
-        void Standard(WithdrawOutput withdrawOutput);
-        void NotFound(string message);
         void OutOfBalance(string message);
     }
 }

--- a/src/Application/Boundaries/Withdraw/IUseCase.cs
+++ b/src/Application/Boundaries/Withdraw/IUseCase.cs
@@ -1,9 +1,4 @@
 namespace Application.Boundaries.Withdraw
 {
-    using System.Threading.Tasks;
-
-    public interface IUseCase
-    {
-        Task Execute(WithdrawInput withdrawInput);
-    }
+    public interface IUseCase : IUseCase<WithdrawInput> { }
 }

--- a/src/Application/Boundaries/Withdraw/WithdrawInput.cs
+++ b/src/Application/Boundaries/Withdraw/WithdrawInput.cs
@@ -4,7 +4,7 @@ namespace Application.Boundaries.Withdraw
     using Exceptions;
     using Domain.ValueObjects;
 
-    public sealed class WithdrawInput
+    public sealed class WithdrawInput : IUseCaseInput
     {
         public Guid AccountId { get; }
         public PositiveMoney Amount { get; }

--- a/src/Application/Boundaries/Withdraw/WithdrawOutput.cs
+++ b/src/Application/Boundaries/Withdraw/WithdrawOutput.cs
@@ -3,7 +3,7 @@ namespace Application.Boundaries.Withdraw
     using Domain.Accounts;
     using Domain.ValueObjects;
 
-    public sealed class WithdrawOutput
+    public sealed class WithdrawOutput : IUseCaseOutput
     {
         public Transaction Transaction { get; }
         public Money UpdatedBalance { get; }


### PR DESCRIPTION
## Summary

I added some interfaces to the Boundaries folder to give more meaning to the IOutputPorts and build them by composition. 

## What changes did I make?

* Adds semantic to boundaries (eea13d2) 

I added 5 interfaces in the Boundaries folder: 
* IUseCaseInput
* IUseCaseOutput
* IUseCase<IUseCaseInput>
* IOutputPortNotFound
* IOutputPortStandard<TUseCaseOutput>

--- 

* IUseCaseInput and IUseCaseOutput are useful for giving semantics.
* IUseCase<IUseCaseInput> allows refactoring of IUseCase interfaces
* IOutputPortNotFound and IOutputPortStandard allow to build by composition the IOutputPort interfaces.

Before
```csharp
    public interface IOutputPort
    {
        void Standard(GetCustomerDetailsOutput getCustomerDetailsOutput);
        void NotFound(string message);
    }
```

After
```csharp
    public interface IOutputPort
        : IOutputPortStandard<GetCustomerDetailsOutput>, IOutputPortNotFound { }
```

---

Does this idea seem interesting to you?