### PR TITLE
Use more concise EqualityMembers

### DIFF
--- a/src/Domain/ValueObjects/Money.cs
+++ b/src/Domain/ValueObjects/Money.cs
@@ -2,9 +2,9 @@ namespace Domain.ValueObjects
 {
     using System;
 
-    public struct Money : IEquatable<Money>
+    public readonly struct Money : IEquatable<Money>
     {
-        private decimal _money;
+        private readonly decimal _money;
 
         public Money(decimal value)
         {
@@ -12,29 +12,16 @@ namespace Domain.ValueObjects
         }
 
         public decimal ToDecimal()
-        {
-            return _money;
-        }
+            => _money;
+
+        public bool Equals(Money other)
+            => _money == other._money;
 
         public override bool Equals(object obj)
-        {
-            if (obj is decimal)
-            {
-                return (decimal) obj == _money;
-            }
-
-            return ((Money) obj)._money == _money;
-        }
+            => obj is Money other && Equals(other);
 
         public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hash = 17;
-                hash = hash * 23 + _money.GetHashCode();
-                return hash;
-            }
-        }
+            => _money.GetHashCode();
 
         internal bool LessThan(PositiveMoney amount)
         {
@@ -44,11 +31,6 @@ namespace Domain.ValueObjects
         internal bool IsZero()
         {
             return _money == 0;
-        }
-
-        public bool Equals(Money other)
-        {
-            return _money == other._money;
         }
 
         internal PositiveMoney Add(Money value)

--- a/src/Domain/ValueObjects/Name.cs
+++ b/src/Domain/ValueObjects/Name.cs
@@ -2,7 +2,7 @@ namespace Domain.ValueObjects
 {
     using System;
 
-    public struct Name : IEquatable<Name>
+    public readonly struct Name : IEquatable<Name>
     {
         private readonly string _text;
 
@@ -19,29 +19,13 @@ namespace Domain.ValueObjects
             return _text;
         }
 
-        public override bool Equals(object obj)
-        {
-            if (obj is string)
-            {
-                return obj.ToString() == _text;
-            }
+        public bool Equals(Name other)
+            => _text == other._text;
 
-            return ((Name) obj)._text == _text;
-        }
+        public override bool Equals(object obj)
+            => obj is Name other && Equals(other);
 
         public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hash = 17;
-                hash = hash * 23 + _text.GetHashCode();
-                return hash;
-            }
-        }
-
-        public bool Equals(Name other)
-        {
-            return _text == other._text;
-        }
+            => _text != null ? _text.GetHashCode() : 0;
     }
 }

--- a/src/Domain/ValueObjects/PositiveMoney.cs
+++ b/src/Domain/ValueObjects/PositiveMoney.cs
@@ -2,7 +2,7 @@ namespace Domain.ValueObjects
 {
     using System;
 
-    public struct PositiveMoney : IEquatable<PositiveMoney>
+    public readonly struct PositiveMoney : IEquatable<PositiveMoney>
     {
         private readonly Money _value;
 
@@ -14,44 +14,26 @@ namespace Domain.ValueObjects
             _value = new Money(value);
         }
 
-        public override bool Equals(object obj)
-        {
-            if (obj is decimal)
-            {
-                return (decimal) obj == _value.ToDecimal();
-            }
-
-            return ((PositiveMoney) obj)._value.ToDecimal() == _value.ToDecimal();
-        }
-
         public Money ToMoney()
-        {
-            return _value;
-        }
+            => _value;
+
+        public bool Equals(PositiveMoney other)
+            => _value.Equals(other._value);
+
+        public override bool Equals(object obj)
+            => obj is PositiveMoney other && Equals(other);
+
+        public override int GetHashCode()
+            => _value.GetHashCode();
 
         internal PositiveMoney Add(PositiveMoney positiveAmount)
         {
             return _value.Add(positiveAmount._value);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hash = 17;
-                hash = hash * 23 + _value.GetHashCode();
-                return hash;
-            }
-        }
-
         internal Money Subtract(PositiveMoney positiveAmount)
         {
             return _value.Subtract(positiveAmount._value);
-        }
-
-        public bool Equals(PositiveMoney other)
-        {
-            return _value.ToDecimal() == other._value.ToDecimal();
         }
     }
 }

--- a/src/Domain/ValueObjects/SSN.cs
+++ b/src/Domain/ValueObjects/SSN.cs
@@ -3,9 +3,9 @@ namespace Domain.ValueObjects
     using System.Text.RegularExpressions;
     using System;
 
-    public struct SSN : IEquatable<SSN>
+    public readonly struct SSN : IEquatable<SSN>
     {
-        private string _text;
+        private readonly string _text;
         const string RegExForValidation = @"^\d{6,8}[-|(\s)]{0,1}\d{4}$";
 
         public SSN(string text)
@@ -23,33 +23,15 @@ namespace Domain.ValueObjects
         }
 
         public override string ToString()
-        {
-            return _text;
-        }
+            => _text;
 
         public bool Equals(SSN other)
-        {
-            return _text == other._text;
-        }
+            => _text == other._text;
 
         public override bool Equals(object obj)
-        {
-            if (obj is string)
-            {
-                return obj.ToString() == _text;
-            }
-
-            return ((SSN) obj)._text == _text;
-        }
+            => obj is SSN other && Equals(other);
 
         public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hash = 17;
-                hash = hash * 23 + _text.GetHashCode();
-                return hash;
-            }
-        }
+            => _text != null ? _text.GetHashCode() : 0;
     }
 }


### PR DESCRIPTION
## Summary

I've refactored the equality members of value objects.
The tests seem to still pass.

**PS:** *Having mistakenly deleted my copy of the repository, I closed the previous pull request attempt.*

## What changes did I make?


* Use readonly fields in ValueObjects (932457b)

We can store the value of a ValueObject in read-only mode.

---

* Fix possibly impure struct method called on readonly variable (4a24511)

---

* Use more concise EqualityMembers (7fd2d29)

```csharp
        public bool Equals(SSN other)
            => _text == other._text;

        public override bool Equals(object obj)
            => obj is SSN other && Equals(other);

        public override int GetHashCode()
            => _text != null ? _text.GetHashCode() : 0;
```

---