### PR TITLE
Configuração do debug por ambiente no VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,12 @@
    "version": "0.2.0",
    "configurations": [
         {
-            "name": ".NET Core Launch (web)",
+            "name": "Development",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/WebApi/bin/Debug/netcoreapp3.0/WebApi.dll",
+            "program": "${workspaceFolder}/src/WebApi/bin/Debug/netcoreapp3.1/WebApi.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/WebApi",
             "stopAtEntry": false,
@@ -27,10 +27,26 @@
             }
         },
         {
-            "name": ".NET Core Attach",
+            "name": "Production",
             "type": "coreclr",
-            "request": "attach",
-            "processId": "${command:pickProcess}"
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/WebApi/bin/Debug/netcoreapp3.1/WebApi.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/WebApi",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "^\\s*Now listening on:\\s+(https?://\\S+)"                
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Production"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
         }
     ]
 }


### PR DESCRIPTION
Configuração do launch.json para realização do debug via **visual studio code** em qualquer ambiente (Linux, Windows e Mac);

Corrigindo o caminho da pasta bin para 3.1
Criando versões com o nome dos ambientes disponíveis baseado nos _appSettings_ existentes.