### PR TITLE
Fix a number of warnings

### DIFF
--- a/src/Infrastructure/InMemoryDataAccess/Presenters/CloseAccountPresenter.cs
+++ b/src/Infrastructure/InMemoryDataAccess/Presenters/CloseAccountPresenter.cs
@@ -15,6 +15,7 @@ namespace Infrastructure.InMemoryDataAccess.Presenters
         {
             this.ClosedAccounts = new Collection<CloseAccountOutput>();
             this.NotFounds = new Collection<string>();
+            this.Errors = new Collection<string>();
         }
 
         /// <summary>

--- a/src/Infrastructure/InMemoryDataAccess/Presenters/DepositPresenter.cs
+++ b/src/Infrastructure/InMemoryDataAccess/Presenters/DepositPresenter.cs
@@ -18,6 +18,7 @@ namespace Infrastructure.InMemoryDataAccess.Presenters
         {
             this.Deposits = new Collection<DepositOutput>();
             this.NotFounds = new Collection<string>();
+            this.Errors = new Collection<string>();
         }
 
         public Collection<DepositOutput> Deposits { get; }

--- a/src/Infrastructure/InMemoryDataAccess/Presenters/GetAccountDetailsPresenter.cs
+++ b/src/Infrastructure/InMemoryDataAccess/Presenters/GetAccountDetailsPresenter.cs
@@ -9,6 +9,7 @@ namespace Infrastructure.InMemoryDataAccess.Presenters
         {
             this.GetAccountDetails = new Collection<GetAccountDetailsOutput>();
             this.NotFounds = new Collection<string>();
+            this.Errors = new Collection<string>();
         }
 
         public Collection<GetAccountDetailsOutput> GetAccountDetails { get; }

--- a/src/Infrastructure/InMemoryDataAccess/Presenters/GetCustomerDetailsPresenter.cs
+++ b/src/Infrastructure/InMemoryDataAccess/Presenters/GetCustomerDetailsPresenter.cs
@@ -9,6 +9,7 @@ namespace Infrastructure.InMemoryDataAccess.Presenters
         {
             this.GetCustomerDetails = new Collection<GetCustomerDetailsOutput>();
             this.NotFounds = new Collection<string>();
+            this.Errors = new Collection<string>();
         }
 
         public Collection<GetCustomerDetailsOutput> GetCustomerDetails { get; }

--- a/src/Infrastructure/InMemoryDataAccess/Presenters/RegisterPresenter.cs
+++ b/src/Infrastructure/InMemoryDataAccess/Presenters/RegisterPresenter.cs
@@ -9,6 +9,7 @@ namespace Infrastructure.InMemoryDataAccess.Presenters
         {
             this.Registers = new Collection<RegisterOutput>();
             this.AlreadyRegistered = new Collection<string>();
+            this.Errors = new Collection<string>();
         }
 
         public Collection<RegisterOutput> Registers { get; }

--- a/src/Infrastructure/InMemoryDataAccess/Presenters/TransferPresenter.cs
+++ b/src/Infrastructure/InMemoryDataAccess/Presenters/TransferPresenter.cs
@@ -9,6 +9,7 @@ namespace Infrastructure.InMemoryDataAccess.Presenters
         {
             this.Transfers = new Collection<TransferOutput>();
             this.NotFounds = new Collection<string>();
+            this.Errors = new Collection<string>();
         }
 
         public Collection<TransferOutput> Transfers { get; }

--- a/src/Infrastructure/InMemoryDataAccess/Presenters/WithdrawPresenter.cs
+++ b/src/Infrastructure/InMemoryDataAccess/Presenters/WithdrawPresenter.cs
@@ -10,6 +10,7 @@ namespace Infrastructure.InMemoryDataAccess.Presenters
             this.Withdrawals = new Collection<WithdrawOutput>();
             this.NotFounds = new Collection<string>();
             this.OutOfBalances = new Collection<string>();
+            this.Errors = new Collection<string>();
         }
 
         public Collection<WithdrawOutput> Withdrawals { get; }

--- a/src/WebApi/Modules/FeatureFlags/CustomControllerFeatureProvider.cs
+++ b/src/WebApi/Modules/FeatureFlags/CustomControllerFeatureProvider.cs
@@ -31,7 +31,7 @@ namespace WebApi.Modules.FeatureFlags
                         foreach (var argumentValue in constructorArgument.Value as IEnumerable)
                         {
                             var typedArgument = (CustomAttributeTypedArgument)argumentValue;
-                            var typedArgumentValue = (Features)(int)typedArgument.Value;
+                            var typedArgumentValue = (Feature)(int)typedArgument.Value;
                             bool isFeatureEnabled = this._featureManager.IsEnabledAsync(typedArgumentValue.ToString())
                                 .ConfigureAwait(false)
                                 .GetAwaiter()

--- a/src/WebApi/Modules/FeatureFlags/Feature.cs
+++ b/src/WebApi/Modules/FeatureFlags/Feature.cs
@@ -1,6 +1,6 @@
 namespace WebApi.Modules.FeatureFlags
 {
-    public enum Features
+    public enum Feature
     {
         Transfer,
         GetAccountDetailsV2

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -3,7 +3,7 @@ namespace WebApi
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Hosting;
 
-    public class Program
+    public static class Program
     {
         public static void Main(string[] args)
         {

--- a/src/WebApi/UseCases/V1/CloseAccount/CloseAccountPresenter.cs
+++ b/src/WebApi/UseCases/V1/CloseAccount/CloseAccountPresenter.cs
@@ -5,7 +5,7 @@ namespace WebApi.UseCases.V1.CloseAccount
 
     public sealed class CloseAccountPresenter : IOutputPort
     {
-        public IActionResult ViewModel { get; private set; }
+        public IActionResult ViewModel { get; private set; } = new NoContentResult();
 
         public void NotFound(string message)
         {

--- a/src/WebApi/UseCases/V1/Deposit/DepositPresenter.cs
+++ b/src/WebApi/UseCases/V1/Deposit/DepositPresenter.cs
@@ -5,7 +5,7 @@ namespace WebApi.UseCases.V1.Deposit
 
     public sealed class DepositPresenter : IOutputPort
     {
-        public IActionResult ViewModel { get; private set; }
+        public IActionResult ViewModel { get; private set; } = new NoContentResult();
 
         public void NotFound(string message)
         {

--- a/src/WebApi/UseCases/V1/GetAccountDetails/GetAccountDetailsPresenter.cs
+++ b/src/WebApi/UseCases/V1/GetAccountDetails/GetAccountDetailsPresenter.cs
@@ -7,7 +7,7 @@ namespace WebApi.UseCases.V1.GetAccountDetails
 
     public sealed class GetAccountDetailsPresenter : IOutputPort
     {
-        public IActionResult ViewModel { get; private set; }
+        public IActionResult ViewModel { get; private set; } = new NoContentResult();
 
         public void NotFound(string message)
         {

--- a/src/WebApi/UseCases/V1/GetCustomerDetails/GetCustomerDetailsPresenter.cs
+++ b/src/WebApi/UseCases/V1/GetCustomerDetails/GetCustomerDetailsPresenter.cs
@@ -7,7 +7,7 @@ namespace WebApi.UseCases.V1.GetCustomerDetails
 
     public sealed class GetCustomerDetailsPresenter : IOutputPort
     {
-        public IActionResult ViewModel { get; private set; }
+        public IActionResult ViewModel { get; private set; } = new NoContentResult();
 
         public void NotFound(string message)
         {

--- a/src/WebApi/UseCases/V1/Register/RegisterPresenter.cs
+++ b/src/WebApi/UseCases/V1/Register/RegisterPresenter.cs
@@ -7,7 +7,7 @@ namespace WebApi.UseCases.V1.Register
 
     public sealed class RegisterPresenter : IOutputPort
     {
-        public IActionResult ViewModel { get; private set; }
+        public IActionResult ViewModel { get; private set; } = new NoContentResult();
 
         public void CustomerAlreadyRegistered(string message)
         {

--- a/src/WebApi/UseCases/V1/Register/RegisterRequest.cs
+++ b/src/WebApi/UseCases/V1/Register/RegisterRequest.cs
@@ -11,7 +11,7 @@ namespace WebApi.UseCases.V1.Register
         ///     Gets or sets sSN.
         /// </summary>
         [Required]
-        public string? SSN { get; set; }
+        public string SSN { get; set; } = string.Empty;
 
         /// <summary>
         ///     Gets or sets initial Amount.

--- a/src/WebApi/UseCases/V1/Register/RegisterRequest.cs
+++ b/src/WebApi/UseCases/V1/Register/RegisterRequest.cs
@@ -11,7 +11,7 @@ namespace WebApi.UseCases.V1.Register
         ///     Gets or sets sSN.
         /// </summary>
         [Required]
-        public string SSN { get; set; }
+        public string? SSN { get; set; }
 
         /// <summary>
         ///     Gets or sets initial Amount.

--- a/src/WebApi/UseCases/V1/Transfer/AccountsController.cs
+++ b/src/WebApi/UseCases/V1/Transfer/AccountsController.cs
@@ -10,7 +10,7 @@ namespace WebApi.UseCases.V1.Transfer
     using Microsoft.FeatureManagement.Mvc;
     using Modules.FeatureFlags;
 
-    [FeatureGate(Features.Transfer)]
+    [FeatureGate(Feature.Transfer)]
     [ApiVersion("1.0")]
     [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]

--- a/src/WebApi/UseCases/V1/Transfer/TransferPresenter.cs
+++ b/src/WebApi/UseCases/V1/Transfer/TransferPresenter.cs
@@ -5,7 +5,7 @@ namespace WebApi.UseCases.V1.Transfer
 
     public sealed class TransferPresenter : IOutputPort
     {
-        public IActionResult ViewModel { get; private set; }
+        public IActionResult ViewModel { get; private set; } = new NoContentResult();
 
         public void NotFound(string message)
         {

--- a/src/WebApi/UseCases/V1/Withdraw/WithdrawPresenter.cs
+++ b/src/WebApi/UseCases/V1/Withdraw/WithdrawPresenter.cs
@@ -5,7 +5,7 @@ namespace WebApi.UseCases.V1.Withdraw
 
     public sealed class WithdrawPresenter : IOutputPort
     {
-        public IActionResult ViewModel { get; private set; }
+        public IActionResult ViewModel { get; private set; } = new NoContentResult();
 
         public void NotFound(string message)
         {

--- a/src/WebApi/UseCases/V2/GetAccountDetails/AccountsController.cs
+++ b/src/WebApi/UseCases/V2/GetAccountDetails/AccountsController.cs
@@ -10,7 +10,7 @@ namespace WebApi.UseCases.V2.GetAccountDetails
     using Microsoft.FeatureManagement.Mvc;
     using Modules.FeatureFlags;
 
-    [FeatureGate(Features.GetAccountDetailsV2)]
+    [FeatureGate(Feature.GetAccountDetailsV2)]
     [ApiVersion("2.0")]
     [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]

--- a/src/WebApi/UseCases/V2/GetAccountDetails/GetAccountDetailsPresenterV2.cs
+++ b/src/WebApi/UseCases/V2/GetAccountDetails/GetAccountDetailsPresenterV2.cs
@@ -8,7 +8,7 @@ namespace WebApi.UseCases.V2.GetAccountDetails
 
     public sealed class GetAccountDetailsPresenterV2 : IOutputPort
     {
-        public IActionResult ViewModel { get; private set; }
+        public IActionResult ViewModel { get; private set; } = new NoContentResult();
 
         public void NotFound(string message)
         {


### PR DESCRIPTION
realtes to #145

## What changed

- Made sure `Errors` property is always instantiated. _(nullable reference types fix)_
- Rename `Features` enum to `Feature`. _(changed according to StyleCop settings)_
- Made Program class static. _(because it's never reference and contains only static members)_
- Initialized SSN to empty string in RegisterRequest.cs. _(because making it nullable would move the problem elsewhere)_
- Default Presenter ViewModels to NoContentResult. _(this is to prevent a null ref and I think "NoContentResult" make sense for a default.)_

## Additional notes

- Not all warnings have been fixed. I'm just leaving it a little better than I found it.
- The build and all unit tests pass.

## Expected feedback

If someone could please double check I'm not doing anything radical. 😅 
So a general sanity check as I like to call it. ❤️ 