### PR TITLE
Adding HealthChecks for EF Core DbContext.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2020-08-04
+
+### Added
+
+- Health Checks in Web Api.
+
 ## [3.1.0] - 2020-07-27
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Version>
-      3.1.0
+      3.2.0
     </Version>
   </PropertyGroup>
 </Project>

--- a/src/WebApi/Modules/HealthChecksExtensions.cs
+++ b/src/WebApi/Modules/HealthChecksExtensions.cs
@@ -1,0 +1,71 @@
+namespace WebApi.Modules
+{
+    using System.Linq;
+    using System.Net.Mime;
+    using System.Threading.Tasks;
+    using Infrastructure.DataAccess;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Diagnostics.HealthChecks;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    ///     HealthChecks Extensions.
+    /// </summary>
+    public static class HealthChecksExtensions
+    {
+        /// <summary>
+        ///     Add Health Checks dependencies varying on configuration.
+        /// </summary>
+        public static IServiceCollection AddHealthChecks(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            IHealthChecksBuilder healthChecks = services.AddHealthChecks();
+
+            bool useFake = configuration.GetValue<bool>("PersistenceModule:UseFake");
+            if (!useFake)
+            {
+                healthChecks.AddDbContextCheck<MangaContext>("MangaDbContext");
+            }
+
+            return services;
+        }
+
+        /// <summary>
+        ///     Use Health Checks dependencies.
+        /// </summary>
+        public static IApplicationBuilder UseHealthChecks(
+            this IApplicationBuilder app)
+        {
+            app.UseHealthChecks("/health",
+                new HealthCheckOptions()
+                {
+                    ResponseWriter = WriteResponse
+                });
+
+            return app;
+        }
+
+        private static Task WriteResponse(HttpContext context, HealthReport result)
+        {
+            context.Response.ContentType = MediaTypeNames.Application.Json;
+
+            var json = new JObject(
+                new JProperty("status", result.Status.ToString()),
+                new JProperty("results", new JObject(result.Entries.Select(pair =>
+                    new JProperty(pair.Key, new JObject(
+                        new JProperty("status", pair.Value.Status.ToString()),
+                        new JProperty("description", pair.Value.Description),
+                        new JProperty("data", new JObject(pair.Value.Data.Select(
+                            p => new JProperty(p.Key, p.Value))))))))));
+
+            return context.Response.WriteAsync(
+                json.ToString(Formatting.Indented));
+        }
+    }
+}

--- a/src/WebApi/Startup.cs
+++ b/src/WebApi/Startup.cs
@@ -31,14 +31,15 @@ namespace WebApi
         public void ConfigureServices(IServiceCollection services) => services
             .AddCurrencyExchange(this.Configuration)
             .AddPersistence(this.Configuration)
+            .AddHealthChecks(this.Configuration)
             .AddAuthentication(this.Configuration)
             .AddFeatureFlags(this.Configuration)
             .AddVersioning()
             .AddSwagger()
             .AddUseCases()
-            .AddCustomControllers()
+            .AddCustomControllers()            
             .AddSpaStaticFiles(configuration => { configuration.RootPath = "ClientApp/build"; });
-
+            
         /// <summary>
         ///     Configure http request pipeline.
         /// </summary>
@@ -67,7 +68,8 @@ namespace WebApi
                 .UseVersionedSwagger(provider, this.Configuration)
                 .UseAuthentication()
                 .UseAuthorization()
-                .UseEndpoints(endpoints => { endpoints.MapControllers(); })
+                .UseHealthChecks()
+                .UseEndpoints(endpoints => { endpoints.MapControllers(); })                
                 .UseSpa(spa =>
                 {
                     spa.Options.SourcePath = "ClientApp";

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -75,6 +75,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.6" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.10.0.19839">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Hi, @ivanpaulovich 

I implemented the health check for EF Core MangaContext.

Below, some examples of expected results.

### PersistenceModule:UseFake => False

**Unhealthy**
```
GET https://localhost:5001/health
{
  "status": "Unhealthy",
  "results": {
    "MangaDbContext": {
      "status": "Unhealthy",
      "description": "A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 40 - Could not open a connection to SQL Server)",
      "data": {}
    }
  }
}
```

**Healthy**
```
GET https://localhost:5001/health
{
  "status": "Healthy",
  "results": {
    "MangaDbContext": {
      "status": "Healthy",
      "description": null,
      "data": {}
    }
  }
}
```


### PersistenceModule:UseFake => True

**Healthy**
```
GET https://localhost:5001/health
{
  "status": "Healthy",
  "results": {}
}
```

Could you, please, validate if:
	- The implementation is in line with what you expected;
	- The implementation follows the project standards;

Maybe for the future, we can open an issue to include an UI (dashboard) to see these statuses.

Thanks,