### PR TITLE
fixes for issue #254 & #249 (ENV MAC)

### DIFF
--- a/accounts-api-seed/Dockerfile
+++ b/accounts-api-seed/Dockerfile
@@ -1,5 +1,6 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS base
-RUN dotnet tool update --global dotnet-ef --version 3.1.8
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+
+RUN dotnet tool update --global dotnet-ef --version 5.0.1
 WORKDIR /src
 COPY . .
 RUN dotnet restore "src/WebApi/WebApi.csproj"

--- a/accounts-api/src/WebApi/entrypoint.sh
+++ b/accounts-api/src/WebApi/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cp /https/localhost.crt /usr/local/share/ca-certificates/localhost.crt
 update-ca-certificates
 dotnet WebApi.dll


### PR DESCRIPTION
fixes for issue #254 & #249
- Upgraded .net SDK build version to 5.0 & tool update 5.0.1
- entry point isn't working in my mac environment (same issue as #249), fixed with the sh enforcement 